### PR TITLE
ForceclassSelf permission checker

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,3 +52,9 @@ CodeCoverage/
 *.VisualState.xml
 TestResult.xml
 nunit-*.xml
+
+# Jetbrains generated files
+.idea/
+Folder.DotSettings.user
+PersistentOverwatch/.idea/
+PersistentOverwatch/Folder.DotSettings.user

--- a/PersistentOverwatch/EventHandlers/RoundRestartHandler.cs
+++ b/PersistentOverwatch/EventHandlers/RoundRestartHandler.cs
@@ -10,6 +10,7 @@ public class RoundRestartHandler : CustomEventsHandler {
     var overwatchPlayerIds =
       from player in Player.List
       where player.Role == RoleTypeId.Overwatch
+      where player.HasPermission(PlayerPermissions.ForceclassSelf)
       select player.UserId;
     
     PersistentOverwatch.Instance.OverwatchIds.UnionWith(overwatchPlayerIds); 


### PR DESCRIPTION
Adds a small check whether the player can change its own class or not. Needed for cases when a mod/admin turns someone else into an overwatch and then leaves the server, leaving the player trapped to be overwatch.